### PR TITLE
feat: use phpstan extension installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 	"config": {
 		"sort-packages": true,
 		"allow-plugins": {
-			"pestphp/pest-plugin": true
+			"pestphp/pest-plugin": true,
+			"phpstan/extension-installer": true
 		},
 		"platform": {
 			"php": "8.2"
@@ -26,6 +27,7 @@
 		"larastan/larastan": "^2.9",
 		"orchestra/testbench": "^8.27",
 		"pestphp/pest": "^2.36",
+		"phpstan/extension-installer": "^1.4",
 		"szepeviktor/phpstan-wordpress": "^1.3",
 		"yard/php-cs-fixer-rules": "^1.0"
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "888fb7a48609a1cf891561168fd2be66",
+    "content-hash": "af33a41b9535fc968a147050869ef72c",
     "packages": [
         {
             "name": "brick/math",
@@ -8119,6 +8119,54 @@
             "time": "2025-11-21T15:09:14+00:00"
         },
         {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "2.3.2",
             "source": {
@@ -11014,7 +11062,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3"
+        "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,3 @@
-includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
-    - vendor/larastan/larastan/extension.neon
-
 parameters:
     level: 8
     paths:


### PR DESCRIPTION
This pull request updates the project's static analysis tooling by adding the `phpstan/extension-installer` package and making related configuration changes. The main goal is to simplify and automate the registration of PHPStan extensions.

Dependency and configuration updates:

* Added `phpstan/extension-installer` to the `require-dev` section in `composer.json` to automatically register PHPStan extensions.
* Updated the `allow-plugins` section in `composer.json` to permit `phpstan/extension-installer` to run as a Composer plugin.

PHPStan configuration simplification:

* Removed manual includes for the Larastan and WordPress PHPStan extensions from `phpstan.neon.dist`, as these are now handled automatically by the extension installer.